### PR TITLE
Use for loops instead of forEach for speed

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -16,10 +16,17 @@ var pt5 = point(19,7, {population: 200});
 var pt6 = point(100,7, {population: 200});
 var ptFC = featureCollection([pt1, pt2, pt3, pt4, pt5, pt6]);
 
+global.within = within;
+global.polyFC = polyFC;
+global.ptFC = ptFC;
+
 var suite = new Benchmark.Suite('turf-within');
 suite
   .add('turf-within',function () {
-    within(ptFC, polyFC);
+    global.within.before(global.ptFC, global.polyFC);
+  })
+  .add('turf-within.fast',function () {
+    global.within.fast(global.ptFC, global.polyFC);
   })
   .on('cycle', function (event) {
     console.log(String(event.target));

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var inside = require('turf-inside');
 var featureCollection = require('turf-featurecollection');
 
-module.exports = function(ptFC, polyFC){
-  pointsWithin = featureCollection([]);
+module.exports.before = function(ptFC, polyFC){
+  var pointsWithin = featureCollection([]);
   polyFC.features.forEach(function(poly){
     ptFC.features.forEach(function(pt){
       var isInside = inside(pt, poly);
@@ -12,4 +12,17 @@ module.exports = function(ptFC, polyFC){
     });
   });
   return pointsWithin;
-}
+};
+
+module.exports.fast = function(ptFC, polyFC){
+  var pointsWithin = featureCollection([]);
+  for (var i = 0; i < polyFC.features.length; i++) {
+    for (var j = 0; j < ptFC.features.length; j++) {
+      var isInside = inside(ptFC.features[j], polyFC.features[i]);
+      if(isInside){
+        pointsWithin.features.push(ptFC.features[j]);
+      }
+    }
+  }
+  return pointsWithin;
+};


### PR DESCRIPTION
```
~/src/turf-within〉node bench.js
turf-within x 392,577 ops/sec ±0.57% (98 runs sampled)
turf-within.fast x 679,989 ops/sec ±0.55% (98 runs sampled)
```

This has old code still in it for comparison purposes - needs a double-tap before merge if it's worth while.
